### PR TITLE
update : set addtime attribute

### DIFF
--- a/rootfs/home/torrent/.rtorrent.rc
+++ b/rootfs/home/torrent/.rtorrent.rc
@@ -25,3 +25,4 @@ schedule = scgi_permission,0,0,"execute.nothrow=chmod,\"g+w,o=\",/tmp/rtorrent.s
 schedule = insufficient_disk_space,1,30,close_low_diskspace=500M
 
 method.set_key=event.download.finished,unrar,"execute={/usr/local/bin/rtunrar.sh,$d.base_path=}"
+method.set_key=event.download.inserted_new,loaded_time,"d.custom.set=addtime,$cat=$system.time=;d.save_full_session="


### PR DESCRIPTION
Sets the addtime attribute for all torrents added through rtorrent (e.g. watch folder).
The addtime attribute is from ruTorrent and is used for sorting in flood, see https://github.com/jfurrow/flood/issues/135