### PR TITLE
Recompile static assets when using different webroot

### DIFF
--- a/rootfs/etc/s6.d/flood/run
+++ b/rootfs/etc/s6.d/flood/run
@@ -1,3 +1,9 @@
 #!/bin/sh
 cd /usr/flood
+
+if [ ! -z ${WEBROOT+x} ] && [ ${WEBROOT} != "/" ]; then
+    npm install
+    npm run build
+fi
+
 exec npm start


### PR DESCRIPTION
Using a different webroot requires a recompile of the static assets. Otherwise a wrong path will be used when retrieving assets.