### PR TITLE
Add info about rTorrent connection type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
 - **PKG_CONFIG_PATH** : `/usr/local/lib/pkgconfig` (don't touch)
 
 ### Note
-Run this container with tty mode enabled. In your `docker-compose.yml`, add `tty: true`. If you don't do this, [rtorrent will use 100% of CPU](https://github.com/Wonderfall/dockerfiles/issues/156).
+- Run this container with tty mode enabled. In your `docker-compose.yml`, add `tty: true`. If you don't do this, [rtorrent will use 100% of CPU](https://github.com/Wonderfall/dockerfiles/issues/156).
+- Connect Flood UI to rTorrent through `Unix socket`. Enter `/tmp/rtorrent.sock` as rTorrent Socket.
 
 #### Ports
 - **49184** (bind it).


### PR DESCRIPTION
The readme is missing info on how to connect Flood to rTorrent.